### PR TITLE
Readme: bin/setup, seeds.rb: set admin role in demo user

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Login to the admin backend at https://alchemy-demo.herokuapp.com/admin
 ## Run the demo locally
 
 1. Clone this repository to your machine
-2. Run `bin/rails setup`
+2. Run 'bin/setup'
 3. Visit http://localhost:3000
 4. Follow on-screen instructions

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,5 +12,5 @@ Alchemy.user_class.create!(
   email: 'demo@example.com',
   password: 'demo123',
   password_confirmation: 'demo123',
-  alchemy_roles: ["admin"]
+  alchemy_roles: ["demo"]
 )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,5 +11,6 @@ Alchemy.user_class.create!(
   login: 'demo',
   email: 'demo@example.com',
   password: 'demo123',
-  password_confirmation: 'demo123'
+  password_confirmation: 'demo123',
+  alchemy_roles: ["admin"]
 )


### PR DESCRIPTION
Related issues:

bin/rails setup : rails aborted! Don't know how to build task 'setup'#4
[alchemy-demo/issues/4](https://github.com/AlchemyCMS/alchemy-demo/issues/4)
-) Readme.MD - change 'bin/rails setup' -> 'bin/setup'

Failed to permit index on :alchemy_admin_dashboard for: #<Alchemy::User id: 1... #1481
[alchemy_cms/issues/1481](https://github.com/AlchemyCMS/alchemy_cms/issues/1481)
-) Seeds.rb - add "admin" role to demo user

**Note**: 
Now the root page show: Routing Error - Alchemy::Page not found "/"
This is expected behaviour since there is no root page.
Related issue:
Show the "Welcome" page also if the root page does not exist or it is not published #1483
[alchemy_cms/issues/1483](https://github.com/AlchemyCMS/alchemy_cms/issues/1483)