### PR TITLE
ci(deps): enable dependabot and alchemy upgrade reminder

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      bundler:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      docker:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/alchemy_upgrade_check.yml
+++ b/.github/workflows/alchemy_upgrade_check.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Remind to run alchemy:upgrade on minor or major bump
         run: |
@@ -21,9 +23,8 @@ jobs:
           }
 
           base_ref="${{ github.base_ref }}"
-          git fetch --no-tags --depth=1 origin "$base_ref"
 
-          old_version="$(git show "FETCH_HEAD:Gemfile.lock" | read_alchemy_version)"
+          old_version="$(git show "origin/${base_ref}:Gemfile.lock" | read_alchemy_version)"
           new_version="$(read_alchemy_version < Gemfile.lock)"
 
           echo "alchemy_cms: ${old_version:-<none>} -> ${new_version:-<none>}"

--- a/.github/workflows/alchemy_upgrade_check.yml
+++ b/.github/workflows/alchemy_upgrade_check.yml
@@ -1,0 +1,46 @@
+name: Alchemy Upgrade Check
+
+on:
+  pull_request:
+    paths:
+      - Gemfile.lock
+
+jobs:
+  alchemy-upgrade-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      - name: Remind to run alchemy:upgrade on minor or major bump
+        run: |
+          set -euo pipefail
+
+          read_alchemy_version() {
+            awk '/^    alchemy_cms \(/ { gsub(/[()]/, "", $2); print $2 }'
+          }
+
+          base_ref="${{ github.base_ref }}"
+          git fetch --no-tags --depth=1 origin "$base_ref"
+
+          old_version="$(git show "FETCH_HEAD:Gemfile.lock" | read_alchemy_version)"
+          new_version="$(read_alchemy_version < Gemfile.lock)"
+
+          echo "alchemy_cms: ${old_version:-<none>} -> ${new_version:-<none>}"
+
+          if [ -z "$old_version" ] || [ -z "$new_version" ] || [ "$old_version" = "$new_version" ]; then
+            echo "No alchemy_cms version change. Nothing to do."
+            exit 0
+          fi
+
+          old_major="${old_version%%.*}"
+          new_major="${new_version%%.*}"
+          old_minor="$(echo "$old_version" | cut -d. -f2)"
+          new_minor="$(echo "$new_version" | cut -d. -f2)"
+
+          if [ "$old_major" != "$new_major" ] || [ "$old_minor" != "$new_minor" ]; then
+            echo "::error::alchemy_cms had a minor or major bump (${old_version} -> ${new_version}). Run \`bin/rails alchemy:upgrade\` locally and commit the generated changes."
+            exit 1
+          fi
+
+          echo "Only a patch-level alchemy_cms change (${old_version} -> ${new_version}). No upgrade task needed."


### PR DESCRIPTION
Dependency bumps currently have to be spotted and applied by hand. Enabling Dependabot turns them into reviewable weekly PRs across the three ecosystems this app relies on: bundler, GitHub Actions, and the Docker base image. Minor and patch updates are grouped per ecosystem to keep the PR count low.

The trickier requirement is running `alchemy:upgrade` after an `alchemy_cms` bump. Dependabot cannot run rake tasks, and auto-running the task in CI is brittle against the `8.3-stable` git-branch pin, so instead a companion check compares the `alchemy_cms` version in `Gemfile.lock` on any PR that touches the lockfile. A minor or major change fails the check with a reminder to run `bin/rails alchemy:upgrade` locally and commit the result; patch-only or unchanged versions pass.

Note: while `alchemy_cms` stays pinned to `8.3-stable` the resolved version remains `8.3.x`, so the reminder effectively guards the moment that pin is later moved to another branch/major or a versioned constraint.